### PR TITLE
Refactor: add call data

### DIFF
--- a/packages/icon-toolkit/package.json
+++ b/packages/icon-toolkit/package.json
@@ -23,7 +23,7 @@
     "@types/bn.js": "^5.1.1",
     "@types/jest": "29.1.1",
     "@types/node": "^18.8.2",
-    "icon-sdk-js": "1.2.6",
+    "icon-sdk-js": "1.2.1",
     "jest": "29.1.2",
     "jsbi": "^4.3.0",
     "lerna": "^5.5.4",

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -23,7 +23,7 @@
     "@convexus/icon-toolkit": "1.1.88",
     "big.js": "^6.2.1",
     "decimal.js-light": "^2.5.1",
-    "icon-sdk-js": "^1.2.6",
+    "icon-sdk-js": "1.2.1",
     "jsbi": "^4.3.0",
     "tiny-invariant": "^1.3.1",
     "toformat": "^2.0.0",

--- a/packages/sdk/src/entities/interface/IAddLiquidityTxs.ts
+++ b/packages/sdk/src/entities/interface/IAddLiquidityTxs.ts
@@ -1,0 +1,7 @@
+import { CallData } from '@convexus/icon-toolkit';
+
+export interface IAddLiquidityTxs {
+  deposit0Tx?: CallData,
+  deposit1Tx?: CallData,
+  mintTx: CallData
+}

--- a/packages/sdk/src/entities/interface/IIncreaseLiquidityTxs.ts
+++ b/packages/sdk/src/entities/interface/IIncreaseLiquidityTxs.ts
@@ -1,0 +1,7 @@
+import { CallData } from '@convexus/icon-toolkit';
+
+export interface IIncreaseLiquidityTxs {
+  deposit0Tx?: CallData,
+  deposit1Tx?: CallData,
+  increaseLiquidityTx: CallData
+}

--- a/packages/sdk/test/nonfungiblePositionManager.test.ts
+++ b/packages/sdk/test/nonfungiblePositionManager.test.ts
@@ -30,10 +30,10 @@ describe('NonfungiblePositionManager', () => {
   const slippageTolerance = new Percent(1, 100)
   const deadline = 123
 
-  describe('#addCallParameters', () => {
+  describe('#buildAddLiquidityTxs', () => {
     it('throws if liquidity is 0', () => {
       expect(() =>
-        NonfungiblePositionManager.addCallParameters(
+        NonfungiblePositionManager.buildAddLiquidityTxs(
           new Position({
             pool: pool_0_1,
             tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
@@ -45,9 +45,9 @@ describe('NonfungiblePositionManager', () => {
       ).toThrow('ZERO_LIQUIDITY')
     })
 
-    it('throws if pool does not involve ICX and useNative is true', () => {
+    it('buildAddLiquidityTxs throws if pool does not involve ICX and useNative is true', () => {
       expect(() =>
-        NonfungiblePositionManager.addCallParameters(
+        NonfungiblePositionManager.buildAddLiquidityTxs(
           new Position({
             pool: pool_0_1,
             tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
@@ -60,7 +60,7 @@ describe('NonfungiblePositionManager', () => {
     })
 
     it('succeeds for mint', () => {
-      const calldata = NonfungiblePositionManager.addCallParameters(
+      const buildAddLiquidityTxs = NonfungiblePositionManager.buildAddLiquidityTxs(
         new Position({
           pool: pool_0_1,
           tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
@@ -70,27 +70,27 @@ describe('NonfungiblePositionManager', () => {
         { recipient, slippageTolerance, deadline }
       )
 
-      expect(calldata[0]).toStrictEqual({
+      expect(buildAddLiquidityTxs.deposit0Tx).toStrictEqual({
         "method": "transfer",
         "params": {
-            "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-            "_to": "NonfungiblePositionManager",
-            "_value": "0x1"
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x1"
         },
         "to": "cx0000000000000000000000000000000000000001"
       })
 
-      expect(calldata[1]).toStrictEqual({
-          "method": "transfer",
-          "params": {
-              "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-              "_to": "NonfungiblePositionManager",
-              "_value": "0x1"
-          },
-          "to": "cx0000000000000000000000000000000000000002"
-       })
+      expect(buildAddLiquidityTxs.deposit1Tx).toStrictEqual({
+        "method": "transfer",
+        "params": {
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x1"
+        },
+        "to": "cx0000000000000000000000000000000000000002"
+      })
 
-      expect(calldata[2]).toStrictEqual({
+      expect(buildAddLiquidityTxs.mintTx).toStrictEqual({
         "to": "NonfungiblePositionManager",
         "method": "mint",
         "params": {
@@ -143,7 +143,7 @@ describe('NonfungiblePositionManager', () => {
       const tickLower = nearestUsableTick(priceToClosestTick(new Price(token1, token2, 1, lowerBoundPrice)), TICK_SPACINGS[highFee])
       const tickUpper = nearestUsableTick(priceToClosestTick(new Price(token1, token2, 1, higherBoundPrice)), TICK_SPACINGS[highFee])
 
-      const calldata = NonfungiblePositionManager.addCallParameters(
+      const buildAddLiquidityTxs = NonfungiblePositionManager.buildAddLiquidityTxs(
         new Position({
           pool: pool_1_2,
           tickLower: tickLower,
@@ -153,27 +153,27 @@ describe('NonfungiblePositionManager', () => {
         { recipient, slippageTolerance, deadline }
       )
 
-      expect(calldata[0]).toStrictEqual({
+      expect(buildAddLiquidityTxs.deposit0Tx).toStrictEqual({
         "method": "transfer",
         "params": {
-            "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-            "_to": "NonfungiblePositionManager",
-            "_value": "0xde5e8740bb55a8a"
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0xde5e8740bb55a8a"
         },
         "to": "cx0000000000000000000000000000000000000002"
       })
 
-      expect(calldata[1]).toStrictEqual({
-          "method": "transfer",
-          "params": {
-              "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-              "_to": "NonfungiblePositionManager",
-              "_value": "0x5726f15f7a74a5b555"
-          },
-          "to": "cx0000000000000000000000000000000000000003"
-       })
+      expect(buildAddLiquidityTxs.deposit1Tx).toStrictEqual({
+        "method": "transfer",
+        "params": {
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x5726f15f7a74a5b555"
+        },
+        "to": "cx0000000000000000000000000000000000000003"
+      })
 
-      expect(calldata[2]).toStrictEqual(
+      expect(buildAddLiquidityTxs.mintTx).toStrictEqual(
         {
           "to": "NonfungiblePositionManager",
           "method": "mint",
@@ -197,7 +197,7 @@ describe('NonfungiblePositionManager', () => {
     })
 
     it('succeeds for full range', () => {
-      const calldata = NonfungiblePositionManager.addCallParameters(
+      const buildIncreaseLiquidityTxs = NonfungiblePositionManager.buildAddLiquidityTxs(
         new Position({
           pool: pool_0_1,
           tickLower: nearestUsableTick(TickMath.MIN_TICK, TICK_SPACINGS[fee]),
@@ -207,27 +207,27 @@ describe('NonfungiblePositionManager', () => {
         { recipient, slippageTolerance, deadline }
       )
 
-      expect(calldata[0]).toStrictEqual({
+      expect(buildIncreaseLiquidityTxs.deposit0Tx).toStrictEqual({
         "method": "transfer",
         "params": {
-            "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-            "_to": "NonfungiblePositionManager",
-            "_value": "0x1"
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x1"
         },
         "to": "cx0000000000000000000000000000000000000001"
       })
 
-      expect(calldata[1]).toStrictEqual({
-          "method": "transfer",
-          "params": {
-              "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-              "_to": "NonfungiblePositionManager",
-              "_value": "0x1"
-          },
-          "to": "cx0000000000000000000000000000000000000002"
-       })
+      expect(buildIncreaseLiquidityTxs.deposit1Tx).toStrictEqual({
+        "method": "transfer",
+        "params": {
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x1"
+        },
+        "to": "cx0000000000000000000000000000000000000002"
+      })
 
-      expect(calldata[2]).toStrictEqual(
+      expect(buildIncreaseLiquidityTxs.mintTx).toStrictEqual(
         {
           "to": "NonfungiblePositionManager",
           "method": "mint",
@@ -250,8 +250,8 @@ describe('NonfungiblePositionManager', () => {
       )
     })
 
-    it('succeeds for full range high fee', () => {
-      const calldata = NonfungiblePositionManager.addCallParameters(
+    it('buildAddLiquidityTxs for full range high fee', () => {
+      const buildAddLiquidityTxs = NonfungiblePositionManager.buildAddLiquidityTxs(
         new Position({
           pool: pool_0_1_fee_high,
           tickLower: nearestUsableTick(TickMath.MIN_TICK, TICK_SPACINGS[feeHigh]),
@@ -261,27 +261,27 @@ describe('NonfungiblePositionManager', () => {
         { recipient, slippageTolerance, deadline }
       )
 
-      expect(calldata[0]).toStrictEqual({
+      expect(buildAddLiquidityTxs.deposit0Tx).toStrictEqual({
         "method": "transfer",
         "params": {
-            "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-            "_to": "NonfungiblePositionManager",
-            "_value": "0x1"
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x1"
         },
         "to": "cx0000000000000000000000000000000000000001"
       })
 
-      expect(calldata[1]).toStrictEqual({
-          "method": "transfer",
-          "params": {
-              "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
-              "_to": "NonfungiblePositionManager",
-              "_value": "0x1"
-          },
-          "to": "cx0000000000000000000000000000000000000002"
-       })
+      expect(buildAddLiquidityTxs.deposit1Tx).toStrictEqual({
+        "method": "transfer",
+        "params": {
+          "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
+          "_to": "NonfungiblePositionManager",
+          "_value": "0x1"
+        },
+        "to": "cx0000000000000000000000000000000000000002"
+      })
 
-      expect(calldata[2]).toStrictEqual(
+      expect(buildAddLiquidityTxs.mintTx).toStrictEqual(
         {
           "to": "NonfungiblePositionManager",
           "method": "mint",
@@ -302,110 +302,140 @@ describe('NonfungiblePositionManager', () => {
           }
         }
       )
-    })
+    })})
 
-    it('succeeds for increase', () => {
-      const pool = new Pool(
-        token0, 
-        token1, 
-        FeeAmount.MEDIUM,
-        JSBI.BigInt("0x24eeafd75f26d0000000000000"),
-        JSBI.BigInt("0x131651bddb3edbbd5d"),
-        0x119f9
-      )
-
-      const newPosition = new Position({
-        pool: pool,
-        tickLower: 0x13470,
-        tickUpper: 0x13524,
-        liquidity: JSBI.BigInt("19087752567891193668198803")
+    describe('#buildIncreaseLiquidityTxs', () => {
+      it('throws if liquidity is 0', () => {
+        expect(() =>
+          NonfungiblePositionManager.buildIncreaseLiquidityTxs(
+            new Position({
+              pool: pool_0_1,
+              tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
+              tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM],
+              liquidity: 0
+            }),
+            { tokenId, slippageTolerance, deadline }
+          )
+        ).toThrow('ZERO_LIQUIDITY')
       })
 
-      const calldata = NonfungiblePositionManager.addCallParameters(
-        newPosition,
-        { tokenId, slippageTolerance, deadline }
-      )
 
-      const expectedValue = "0x" + newPosition.amount0.quotient.toString(16)
+    it('buildIncreaseLiquidityTxs throws if pool does not involve ICX and useNative is true', () => {
+      expect(() =>
+        NonfungiblePositionManager.buildIncreaseLiquidityTxs(
+          new Position({
+            pool: pool_0_1,
+            tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
+            tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM],
+            liquidity: 1
+          }),
+          { tokenId, slippageTolerance, deadline, useNative: ICX }
+        )
+      ).toThrow('NO_WICX')
+    })
 
-      expect(calldata[0]).toStrictEqual({
-        "method": "transfer",
-        "params": {
+      it('succeeds for increase', () => {
+        const pool = new Pool(
+          token0,
+          token1,
+          FeeAmount.MEDIUM,
+          JSBI.BigInt("0x24eeafd75f26d0000000000000"),
+          JSBI.BigInt("0x131651bddb3edbbd5d"),
+          0x119f9
+        )
+
+        const newPosition = new Position({
+          pool: pool,
+          tickLower: 0x13470,
+          tickUpper: 0x13524,
+          liquidity: JSBI.BigInt("19087752567891193668198803")
+        })
+
+        const buildIncreaseLiquidityTxs = NonfungiblePositionManager.buildIncreaseLiquidityTxs(
+          newPosition,
+          { tokenId, slippageTolerance, deadline }
+        )
+
+        const expectedValue = "0x" + newPosition.amount0.quotient.toString(16)
+
+        expect(buildIncreaseLiquidityTxs.deposit0Tx).toStrictEqual({
+          "method": "transfer",
+          "params": {
             "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
             "_to": "NonfungiblePositionManager",
             "_value": expectedValue
-        },
-        "to": "cx0000000000000000000000000000000000000001"
+          },
+          "to": "cx0000000000000000000000000000000000000001"
+        })
+
+        expect(buildIncreaseLiquidityTxs.increaseLiquidityTx).toStrictEqual(
+          {
+            "to": "NonfungiblePositionManager",
+            "method": "increaseLiquidity",
+            "params": {
+              "params": {
+                "amount0Desired": "0x" + newPosition.amount0.quotient.toString(16),
+                "amount0Min": "0x" + newPosition.amount0.quotient.toString(16),
+                "amount1Desired": "0x0",
+                "amount1Min": "0x0",
+                "deadline": "0x7b",
+                "tokenId": "0x1"
+              }
+            }
+          }
+        )
       })
 
-      expect(calldata[1]).toStrictEqual(
-        {
-          "to": "NonfungiblePositionManager",
-          "method": "increaseLiquidity",
-          "params": {
-            "params": {
-              "amount0Desired": "0x" + newPosition.amount0.quotient.toString(16),
-              "amount0Min": "0x" + newPosition.amount0.quotient.toString(16),
-              "amount1Desired": "0x0",
-              "amount1Min": "0x0",
-              "deadline": "0x7b",
-              "tokenId": "0x1"
-              }
-          }
-        }
-      )
-    })
- 
-    it('useNative', () => {
-      const calldata = NonfungiblePositionManager.addCallParameters(
-        new Position({
-          pool: pool_1_wicx,
-          tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
-          tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM],
-          liquidity: 1
-        }),
-        { recipient, slippageTolerance, deadline, useNative: ICX }
-      )
+      it('useNative', () => {
+        const buildAddLiquidityTxs = NonfungiblePositionManager.buildAddLiquidityTxs(
+          new Position({
+            pool: pool_1_wicx,
+            tickLower: -TICK_SPACINGS[FeeAmount.MEDIUM],
+            tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM],
+            liquidity: 1
+          }),
+          { recipient, slippageTolerance, deadline, useNative: ICX }
+        )
 
-      expect(calldata[0]).toStrictEqual({
-        "method": "transfer",
-        "params": {
+        expect(buildAddLiquidityTxs.deposit0Tx).toStrictEqual({
+          "method": "transfer",
+          "params": {
             "_data": "0x7b226d6574686f64223a226465706f736974222c22706172616d73223a7b7d7d",
             "_to": "NonfungiblePositionManager",
             "_value": "0x1"
-        },
-        "to": "cx0000000000000000000000000000000000000002"
-      })
+          },
+          "to": "cx0000000000000000000000000000000000000002"
+        })
 
-      expect(calldata[1]).toStrictEqual({
+        expect(buildAddLiquidityTxs.deposit1Tx).toStrictEqual({
           "to": "NonfungiblePositionManager",
           "method": "depositIcx",
           "value": "0x1"
         })
 
-      expect(calldata[2]).toStrictEqual(
-        {
-          "to": "NonfungiblePositionManager",
-          "method": "mint",
-          "params": {
+        expect(buildAddLiquidityTxs.mintTx).toStrictEqual(
+          {
+            "to": "NonfungiblePositionManager",
+            "method": "mint",
             "params": {
-              "amount0Desired": "0x1",
-              "amount0Min": "0x0",
-              "amount1Desired": "0x1",
-              "amount1Min": "0x0",
-              "deadline": "0x7b",
-              "fee": "0xbb8",
-              "recipient": "hx0000000000000000000000000000000000000003",
-              "tickLower": "-0x3c",
-              "tickUpper": "0x3c",
-              "token0": "cx0000000000000000000000000000000000000002",
-              "token1": "cx1111111111111111111111111111111111111111"
+              "params": {
+                "amount0Desired": "0x1",
+                "amount0Min": "0x0",
+                "amount1Desired": "0x1",
+                "amount1Min": "0x0",
+                "deadline": "0x7b",
+                "fee": "0xbb8",
+                "recipient": "hx0000000000000000000000000000000000000003",
+                "tickLower": "-0x3c",
+                "tickUpper": "0x3c",
+                "token0": "cx0000000000000000000000000000000000000002",
+                "token1": "cx1111111111111111111111111111111111111111"
+              }
             }
           }
-        }
-      )
+        )
+      })
     })
-  })
 
   describe('#collectCallParameters', () => {
     it('works', () => {
@@ -509,7 +539,7 @@ describe('NonfungiblePositionManager', () => {
         )
       ).toThrow('ZERO_LIQUIDITY')
     })
- 
+
     it('throws for bad burn', () => {
       expect(() =>
         NonfungiblePositionManager.removeCallParameters(
@@ -749,7 +779,7 @@ describe('NonfungiblePositionManager', () => {
       )
     })
   })
-  
+
   describe('#safeTransferFromParameters', () => {
     it('succeeds no data param', () => {
       const options = {
@@ -774,7 +804,7 @@ describe('NonfungiblePositionManager', () => {
       ]
       )
     })
-    
+
     it('succeeds data param', () => {
       const data = '0x0000000000000000000000000000000000009004'
       const options = {

--- a/packages/sdk/test/poolInitializer.test.ts
+++ b/packages/sdk/test/poolInitializer.test.ts
@@ -78,7 +78,7 @@ describe('PoolInitializer', () => {
     const slippageTolerance = new Percent(1, 100)
     const deadline = 123
 
-    NonfungiblePositionManager.addCallParameters(
+    NonfungiblePositionManager.buildAddLiquidityTxs(
       new Position({
         pool: pool_0_1,
         tickLower: tickLower,
@@ -92,21 +92,21 @@ describe('PoolInitializer', () => {
   it('create initialize mint', () => {
     // Init price: 1 token0 = 600 token1
     const sqrtRatioX96 = encodeSqrtRatioX96(600, 1)
-    
+
     // Provide liquidity between 500 and 800
     const lowerBoundPrice = 500
     const higherBoundPrice = 800
-    
+
     const tickLower = nearestUsableTick(priceToClosestTick(new Price(token0, token1, 1, lowerBoundPrice)), TICK_SPACINGS[fee])
     const tickUpper = nearestUsableTick(priceToClosestTick(new Price(token0, token1, 1, higherBoundPrice)), TICK_SPACINGS[fee])
-    
+
     // Create a virtual pool
     const pool = new Pool(token0, token1, fee, sqrtRatioX96, 0, TickMath.getTickAtSqrtRatio(sqrtRatioX96))
-    
+
     const EXA = JSBI.BigInt(10**18)
     const amount0 = JSBI.multiply(EXA, JSBI.BigInt(5)) // 5 token0
     const amount1 = MaxUint256 // compute amount1 needed
-    
+
     // Compute the max liquidity given the amounts
     const liquidity = maxLiquidityForAmounts (
       pool.sqrtRatioX96, // Pool price
@@ -126,10 +126,10 @@ describe('PoolInitializer', () => {
     // adress that will receive the position NFT
     const recipient = 'hx0000000000000000000000000000000000000003'
     const deadline = 123
-    
+
     // Initialize the pool + mint position
     const calldatas = PoolInitializer.createAndMintCallParameters(position, recipient, deadline)
-    
+
     expect(calldatas[0]).toStrictEqual({
       "method": "transfer",
       "params": {
@@ -139,7 +139,7 @@ describe('PoolInitializer', () => {
       },
       "to": "cx0000000000000000000000000000000000000001"
     })
-    
+
     expect(calldatas[1]).toStrictEqual({
       "method": "transfer",
       "params": {
@@ -149,7 +149,7 @@ describe('PoolInitializer', () => {
       },
       "to": "cx0000000000000000000000000000000000000002"
     })
-    
+
     expect(calldatas[2]).toStrictEqual(
       {
         "to": "PoolInitializer",


### PR DESCRIPTION
I split addCallParameters method to buildAddLiquidityTxs and buildIncreaseLiquidityTxs methods with appropriate interfaced objects returned. Icon sdk lib was downgraded to the node.js v16 compatible version.

This PR improves the returned objects of before addCallParameters method (split) by interfacing them.